### PR TITLE
ajusta delimitador de aspas dentro de string iniciada sem aspas.

### DIFF
--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -3,14 +3,23 @@
 /*                                                        :::      ::::::::   */
 /*   get_token_len.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/03/15 14:54:39 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/03/29 22:47:54 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../minishell.h"
+
+static int	is_token_delimiter(char c)
+{
+	if (c == ' ' || c == '|' || c == '<' || c == '>'
+		|| c == '\t' || c == '\n'
+		|| c == '\"' || c == '\'')
+		return (EXIT_SUCCESS);
+	return (EXIT_FAILURE);
+}
 
 int	get_token_len(char *str)
 {
@@ -32,7 +41,7 @@ int	get_token_len(char *str)
 		return (2);
 	while (str[i] != '\0')
 	{
-		if (str[i] == ' ' || str[i] == '|' || str[i] == '<' || str[i] == '>')
+		if (is_token_delimiter(str[i]) == EXIT_SUCCESS)
 			break ;
 		i++;
 	}

--- a/tests/test-set_tokens.c
+++ b/tests/test-set_tokens.c
@@ -198,6 +198,30 @@ int	create_list_with_simple_quotes_between_double_quotes(void)
 	}
 }
 
+int	should_create_list_with_quotes_combination(void)
+{
+	char	str_in[] = "echo 'mixed\"quotes'and\"more\"";
+	t_token	*token = NULL;
+
+	token = set_tokens(str_in);
+	if (!token)
+		return (EXIT_FAILURE);
+	if (ft_strncmp(token->value, "echo", 4) == EXIT_SUCCESS
+		&& ft_strncmp(token->next->value, "\'mixed\"quotes\'", 14) == EXIT_SUCCESS
+		&& ft_strncmp(token->next->next->value, "and", 3) == EXIT_SUCCESS
+		&& ft_strncmp(token->next->next->next->value, "\"more\"", 6) == EXIT_SUCCESS
+		&& token->next->next->next->next == NULL)
+	{
+		clear_token_list(&token);
+		return (EXIT_SUCCESS);
+	}
+	else
+	{
+		clear_token_list(&token);
+		return (EXIT_FAILURE);
+	}
+}
+
 int	set_correctly_reverse_link_for_list_of_three(void)
 {
 	char	str_in[] = "token size test";
@@ -459,6 +483,7 @@ int	main(void)
 	RUN_TEST(create_list_ignoring_spaces);
 	RUN_TEST(create_list_with_input_containing_pipe_with_spaces);
 	RUN_TEST(create_list_with_simple_quotes_between_double_quotes);
+	RUN_TEST(should_create_list_with_quotes_combination);
 	RUN_TEST(set_correctly_reverse_link_for_list_of_three);
 	RUN_TEST(set_correctly_list_for_input_with_pipe_and_no_space);
 	RUN_TEST(set_correctly_list_for_input_with_redirect_in_and_no_space);


### PR DESCRIPTION
Ajuste para tokenização correta em casos de strings com aspas simples e duplas de maneira intercalada.
Inclui caso iniciado por caractere simples (sem ser aspas).