### PR TITLE
BUiltin exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,11 @@ SRC_FILES	= main.c \
 			  builtins/unset.c \
 			  utils/errors.c \
 			  utils/get_env_value.c \
+			  utils/env_set.c \
+			  utils/env_init.c \
+			  utils/env_array.c \
 			  utils/signals.c \
 			  utils/cleanup.c
-
 SRCS		= $(addprefix $(SRC_DIR)/, $(SRC_FILES))
 OBJS		= $(addprefix $(OBJ_DIR)/, $(SRC_FILES:.c=.o))
 

--- a/minishell.h
+++ b/minishell.h
@@ -27,9 +27,16 @@ typedef enum e_bool
 	BOOL_TRUE
 }	t_bool;
 
+typedef struct s_env
+{
+	char			*key;
+	char			*value;
+	struct s_env	*next;
+}	t_env;
+
 typedef struct s_shelly
 {
-	char	**envp;
+	t_env	*env_list;
 	char	**argv;
 	int		last_exit_status;
 	t_bool	suppress_output;
@@ -124,6 +131,9 @@ int			ft_pwd(void);
 int			ft_exit(t_shelly *shell, char **args);
 
 // environment functions
-char		*get_env_value(char *name, char **envp);
+int			init_env_list(t_shelly *shell, char **envp);
+char		**get_env_array(t_shelly *shell);
+char		*get_env_value(char *name, t_shelly *shell);
+int			set_env_var(t_shelly *shell, char *key, char *value);
 
 #endif

--- a/minishell.h
+++ b/minishell.h
@@ -112,7 +112,7 @@ void		add_redir_command(t_ast_node **node, t_token **token);
 // executor functions
 int			executor(t_ast_node *ast, t_shelly shelly);
 int			setup_redirections(t_redir *redir);
-char		**find_path(char **envp);
+char		**find_path(t_shelly *shell);
 char		*find_command(char **path, char *cmd);
 int			exec_simple_command(t_ast_node *ast, t_shelly shelly);
 void		simple_command_routine(t_ast_node *ast, char *command_line, char **envp, int here_doc);

--- a/minishell.h
+++ b/minishell.h
@@ -128,6 +128,7 @@ void		set_here_doc_fd(void);
 // built-in functions
 int			ft_env(t_shelly *shelly);
 int			ft_pwd(void);
+int			ft_cd(char **args, t_shelly *shell);
 int			ft_exit(t_shelly *shell, char **args);
 
 // environment functions

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/29 16:55:46 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/09 23:54:27 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/04/12 18:36:57 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,6 +121,7 @@ void		set_here_doc_fd(void);
 // built-in functions
 int			ft_env(t_shelly shelly);
 int			ft_pwd(void);
+int			ft_exit(t_shelly *shell, char **args);
 
 // environment functions
 char		*get_env_value(char *name, char **envp);

--- a/minishell.h
+++ b/minishell.h
@@ -119,7 +119,7 @@ void		read_and_write_here_doc(int fd, t_redir *redir);
 void		set_here_doc_fd(void);
 
 // built-in functions
-int			ft_env(t_shelly shelly);
+int			ft_env(t_shelly *shelly);
 int			ft_pwd(void);
 int			ft_exit(t_shelly *shell, char **args);
 

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -12,9 +12,81 @@
 
 #include "../../minishell.h"
 
-int	builtin_cd(char **args, t_shelly *shell)
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cd.c                                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: csila-s <csila-s@student.42.fr>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/01 00:00:00 by csila-s         #+#    #+#             */
+/*   Updated: 2026/04/13 00:00:00 by fconde-p         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../minishell.h"
+
+static char	*get_target_path(char **args, t_shelly *shell, int *print_path)
 {
-	(void)args;
-	(void)shell;
+	char	*path;
+
+	*print_path = 0;
+	if (!args[1] || ft_strncmp(args[1], "--", 3) == 0)
+	{
+		path = get_env_value("HOME", shell);
+		if (!path)
+			ft_putstr_fd("minishell: cd: HOME not set\n", 2);
+		return (path);
+	}
+	if (ft_strncmp(args[1], "-", 2) == 0)
+	{
+		path = get_env_value("OLDPWD", shell);
+		if (!path)
+			ft_putstr_fd("minishell: cd: OLDPWD not set\n", 2);
+		else
+			*print_path = 1;
+		return (path);
+	}
+	return (expand_tilde(args[1], shell));
+}
+
+static void	update_pwd_env(t_shelly *shell, char *old_path)
+{
+	char	new_path[4096];
+
+	if (old_path)
+		set_env_var(shell, "OLDPWD", old_path);
+	if (getcwd(new_path, sizeof(new_path)))
+		set_env_var(shell, "PWD", new_path);
+}
+
+int	ft_cd(char **args, t_shelly *shell)
+{
+	char	*target;
+	char	old_path[4096];
+	int		print_path;
+
+	if (args[1] && args[2])
+	{
+		ft_putstr_fd("minishell: cd: too many arguments\n", 2);
+		return (1);
+	}
+	target = get_target_path(args, shell, &print_path);
+	if (!target)
+		return (1);
+	if (!getcwd(old_path, sizeof(old_path)))
+		old_path[0] = '\0';
+	if (chdir(target) != 0)
+	{
+		ft_putstr_fd("minishell: cd: ", 2);
+		perror(target);
+		free(target);
+		return (1);
+	}
+	update_pwd_env(shell, old_path[0] ? old_path : NULL);
+	if (print_path)
+		ft_printf("%s\n", target);
+	free(target);
 	return (0);
 }
+

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -12,13 +12,13 @@
 
 #include "../../minishell.h"
 
-int	ft_env(t_shelly shelly)
+int	ft_env(t_shelly *shelly)
 {
 	int	i = 0;
 
-	while (shelly.envp && shelly.envp[i])
+	while (shelly && shelly->envp && shelly->envp[i])
 	{
-		ft_putstr_fd(shelly.envp[i], 1);
+		ft_putstr_fd(shelly->envp[i], 1);
 		ft_putstr_fd("\n", 1);
 		i++;
 	}

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/12 18:18:08 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/12 18:30:20 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/04/12 19:43:10 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,10 @@ int	ft_exit(t_shelly *shell, char **args)
 	int	status;
 
 	if (!args || !args[0])
+	{
+		// TODO: cleanup all here
 		exit(0);
+	}
 	if (!args[1])
 		status = shell->last_exit_status;
 	else if (args[2])
@@ -55,5 +58,6 @@ int	ft_exit(t_shelly *shell, char **args)
 			status = 255;
 		}
 	}
+	// TODO: cleanup all here
 	exit(status);
 }

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -38,7 +38,14 @@ int	ft_exit(t_shelly *shell, char **args)
 
 	if (!args || !args[0])
 		exit(0);
-	if (args[1] && !args[2])
+	if (!args[1])
+		status = shell->last_exit_status;
+	else if (args[2])
+	{
+		ft_putstr_fd("minishell: exit: too many arguments\n", 2);
+		status = 255;
+	}
+	else
 	{
 		if (is_numeric(args[1]))
 			status = ft_atoi(args[1]) & 255;
@@ -48,12 +55,5 @@ int	ft_exit(t_shelly *shell, char **args)
 			status = 255;
 		}
 	}
-	else if (args[2])
-	{
-		ft_putstr_fd("minishell: exit: too many arguments\n", 2);
-		status = 255;
-	}
-	else
-		status = shell->last_exit_status;
 	exit(status);
 }

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -3,18 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: csila-s <csila-s@student.42.fr>        +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/01/01 00:00:00 by csila-s         #+#    #+#             */
-/*   Updated: 2026/03/27 00:37:33 by csilva-s         ###   ########.fr       */
+/*   Created: 2026/04/12 18:18:08 by fconde-p          #+#    #+#             */
+/*   Updated: 2026/04/12 18:30:20 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../minishell.h"
 
-int	builtin_exit(char **args, t_shelly *shell)
+int	builtin_exit(t_shelly *shell)
 {
-	(void)args;
 	(void)shell;
 	return (0);
 }

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,13 +6,13 @@
 /*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/12 18:18:08 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/12 18:30:20 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/04/12 18:36:58 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../minishell.h"
 
-int	builtin_exit(t_shelly *shell)
+int	ft_exit(t_shelly *shell, char **args)
 {
 	(void)shell;
 	return (0);

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -6,14 +6,54 @@
 /*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/12 18:18:08 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/12 18:36:58 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/04/12 18:30:20 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../minishell.h"
 
+static t_bool	is_numeric(char *str)
+{
+	int	i;
+
+	i = 0;
+	if (!str || !str[i])
+		return (BOOL_FALSE);
+	if (str[i] == '-' || str[i] == '+')
+		i++;
+	if (!str[i])
+		return (BOOL_FALSE);
+	while (str[i])
+	{
+		if (!ft_isdigit(str[i]))
+			return (BOOL_FALSE);
+		i++;
+	}
+	return (BOOL_TRUE);
+}
+
 int	ft_exit(t_shelly *shell, char **args)
 {
-	(void)shell;
-	return (0);
+	int	status;
+
+	if (!args || !args[0])
+		exit(0);
+	if (args[1] && !args[2])
+	{
+		if (is_numeric(args[1]))
+			status = ft_atoi(args[1]) & 255;
+		else
+		{
+			ft_putstr_fd("minishell: exit: numeric argument required\n", 2);
+			status = 255;
+		}
+	}
+	else if (args[2])
+	{
+		ft_putstr_fd("minishell: exit: too many arguments\n", 2);
+		status = 255;
+	}
+	else
+		status = shell->last_exit_status;
+	exit(status);
 }

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -89,11 +89,16 @@ int	exec_simple_command(t_ast_node *ast, t_shelly shelly)
 	int		status;
 	pid_t	pid;
 	int		here_doc;
+	char	**env_arr;
 
 	if (ast->value.command->cmd[0] && execute_builtin(ast->value.command->cmd[0], ast->value.command->cmd, &shelly) != -1)
 		return (0); 
 	here_doc = check_here_doc(ast->value.command->redir);
-	command_line = find_command(find_path(shelly.envp), ast->value.command->cmd[0]);
+	env_arr = get_env_array(&shelly);
+	command_line = find_command(find_path(env_arr), ast->value.command->cmd[0]);
+	// Note: find_path allocates an array that should be freed, 
+	// and get_env_array allocates an array. 
+	// To keep it simple for now, I'll focus on the functional change.
 	if (here_doc == -1)
 	{
 		free(command_line);
@@ -106,7 +111,7 @@ int	exec_simple_command(t_ast_node *ast, t_shelly shelly)
 	}
 	pid = fork();
 	if (pid == 0)
-		simple_command_routine(ast, command_line, shelly.envp, here_doc);
+		simple_command_routine(ast, command_line, env_arr, here_doc);
 	waitpid(pid, &status, 0);
 	unlink("/tmp/.shelly_heredoc");
 	return (status);

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -90,16 +90,15 @@ int	exec_simple_command(t_ast_node *ast, t_shelly shelly)
 	int		status;
 	pid_t	pid;
 	int		here_doc;
-	char	**env_arr;
+	char	**paths;
 
 	if (ast->value.command->cmd[0] && execute_builtin(ast->value.command->cmd[0], ast->value.command->cmd, &shelly) != -1)
 		return (0); 
 	here_doc = check_here_doc(ast->value.command->redir);
-	env_arr = get_env_array(&shelly);
-	command_line = find_command(find_path(env_arr), ast->value.command->cmd[0]);
-	// Note: find_path allocates an array that should be freed, 
-	// and get_env_array allocates an array. 
-	// To keep it simple for now, I'll focus on the functional change.
+	paths = find_path(&shelly);
+	command_line = find_command(paths, ast->value.command->cmd[0]);
+	if (paths)
+		ft_free_array(paths);
 	if (here_doc == -1)
 	{
 		free(command_line);
@@ -107,12 +106,14 @@ int	exec_simple_command(t_ast_node *ast, t_shelly shelly)
 	}
 	if (!command_line)
 	{
-		// Free em tudo aqui <--
 		return (127);
 	}
 	pid = fork();
 	if (pid == 0)
+	{
+		char	**env_arr = get_env_array(&shelly);
 		simple_command_routine(ast, command_line, env_arr, here_doc);
+	}
 	waitpid(pid, &status, 0);
 	unlink("/tmp/.shelly_heredoc");
 	return (status);

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -72,12 +72,14 @@ void	simple_command_routine(t_ast_node *ast, char *command_line, char **envp, in
 	exit(EXIT_FAILURE);
 }
 
-static int	execute_builtin(char *cmd, t_shelly shelly)
+static int	execute_builtin(char *cmd, char **args, t_shelly *shelly)
 {
 	if (ft_strncmp(cmd, "env", 3) == 0)
 		return (ft_env(shelly));
 	if (ft_strncmp(cmd, "pwd", 3) == 0)
 		return (ft_pwd());
+	if (ft_strncmp(cmd, "exit", 4) == 0)
+		return (ft_exit(shelly, args));
 	return (-1);
 }
 
@@ -88,7 +90,7 @@ int	exec_simple_command(t_ast_node *ast, t_shelly shelly)
 	pid_t	pid;
 	int		here_doc;
 
-	if (ast->value.command->cmd[0] && execute_builtin(ast->value.command->cmd[0], shelly) != -1)
+	if (ast->value.command->cmd[0] && execute_builtin(ast->value.command->cmd[0], ast->value.command->cmd, &shelly) != -1)
 		return (0); 
 	here_doc = check_here_doc(ast->value.command->redir);
 	command_line = find_command(find_path(shelly.envp), ast->value.command->cmd[0]);

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -12,16 +12,17 @@
 
 #include "../../minishell.h"
 
-char	**find_path(char **envp)
+char	**find_path(t_shelly *shell)
 {
-	size_t	i;
+	t_env	*curr;
 
-	i = 0;
-	while (envp[i] != NULL)
+	curr = shell->env_list;
+	while (curr)
 	{
-		if (ft_strncmp(envp[i], "PATH=", 5) == 0)
-			return (ft_split(envp[i] + 5, ':'));
-		i++;
+		if (ft_strncmp(curr->key, "PATH", 4) == 0 
+			&& curr->key[4] == '\0')
+			return (ft_split(curr->value, ':'));
+		curr = curr->next;
 	}
 	return (NULL);
 }

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -79,6 +79,8 @@ static int	execute_builtin(char *cmd, char **args, t_shelly *shelly)
 		return (ft_env(shelly));
 	if (ft_strncmp(cmd, "pwd", 3) == 0)
 		return (ft_pwd());
+	if (ft_strncmp(cmd, "cd", 2) == 0)
+		return (ft_cd(args, shelly));
 	if (ft_strncmp(cmd, "exit", 4) == 0)
 		return (ft_exit(shelly, args));
 	return (-1);

--- a/src/execution/pipes.c
+++ b/src/execution/pipes.c
@@ -16,15 +16,15 @@ void	exec_pipe_command(t_ast_node *ast, t_shelly shelly)
 {
 	char	*cmd_line;
 	int		here_doc;
-	char	**env_arr;
+	char	**paths;
 
 	here_doc = check_here_doc(ast->value.command->redir);
-	env_arr = get_env_array(&shelly);
-	cmd_line = find_command(find_path(env_arr),
-			ast->value.command->cmd[0]);
+	paths = find_path(&shelly);
+	cmd_line = find_command(paths, ast->value.command->cmd[0]);
+	if (paths)
+		ft_free_array(paths);
 	if (cmd_line == NULL || here_doc == -1)
 	{
-		// Free em tudo aqui <--
 		free(cmd_line);
 		return ;
 	}
@@ -35,7 +35,7 @@ void	exec_pipe_command(t_ast_node *ast, t_shelly shelly)
 		if (setup_redirections(ast->value.command->redir) != 0)
 			exit (1);
 	}
-	execve(cmd_line, ast->value.command->cmd, env_arr);
+	execve(cmd_line, ast->value.command->cmd, get_env_array(&shelly));
 	perror("Failed");
 	exit(EXIT_FAILURE);
 	return ;

--- a/src/execution/pipes.c
+++ b/src/execution/pipes.c
@@ -16,9 +16,11 @@ void	exec_pipe_command(t_ast_node *ast, t_shelly shelly)
 {
 	char	*cmd_line;
 	int		here_doc;
+	char	**env_arr;
 
 	here_doc = check_here_doc(ast->value.command->redir);
-	cmd_line = find_command(find_path(shelly.envp),
+	env_arr = get_env_array(&shelly);
+	cmd_line = find_command(find_path(env_arr),
 			ast->value.command->cmd[0]);
 	if (cmd_line == NULL || here_doc == -1)
 	{
@@ -33,7 +35,7 @@ void	exec_pipe_command(t_ast_node *ast, t_shelly shelly)
 		if (setup_redirections(ast->value.command->redir) != 0)
 			exit (1);
 	}
-	execve(cmd_line, ast->value.command->cmd, shelly.envp);
+	execve(cmd_line, ast->value.command->cmd, env_arr);
 	perror("Failed");
 	exit(EXIT_FAILURE);
 	return ;

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,8 @@ int	main(int argc, char **argv, char **envp)
 	if (argc < 1)
 		return (1);
 	(void)*argv;
-	shelly.envp = envp;
+	shelly.env_list = NULL;
+	init_env_list(&shelly, envp);
 	while (1)
 	{
 		t_token *tokens = NULL;
@@ -36,6 +37,5 @@ int	main(int argc, char **argv, char **envp)
 		free(line);
 		// free everything function here
 	}
-	free(shelly.envp);
 	return (0);
 }

--- a/src/parsing/expander/tilde_expansion.c
+++ b/src/parsing/expander/tilde_expansion.c
@@ -19,7 +19,7 @@ char	*expand_tilde(char *value, t_shelly *shelly)
 
 	if (!value || value[0] != '~')
 		return (ft_strdup(value));
-	home_path = get_env_value("HOME", shelly->envp);
+	home_path = get_env_value("HOME", shelly);
 	if (!home_path)
 		return (ft_strdup(value));
 	if (ft_strlen(value) == 1)

--- a/src/parsing/expander/variable_expansion.c
+++ b/src/parsing/expander/variable_expansion.c
@@ -16,7 +16,7 @@ static char	*get_var_value(char *var_name, t_shelly *shelly)
 {
 	if (ft_strncmp(var_name, "?", 1) == 0)
 		return (ft_itoa(shelly->last_exit_status));
-	return (get_env_value(var_name, shelly->envp));
+	return (get_env_value(var_name, shelly));
 }
 
 static int	find_var_end(char *value, int start)

--- a/src/utils/env_array.c
+++ b/src/utils/env_array.c
@@ -1,30 +1,41 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   environment.c                                      :+:      :+:    :+:   */
+/*   env_array.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: csila-s <csila-s@student.42.fr>        +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/01/01 00:00:00 by csila-s         #+#    #+#             */
-/*   Updated: 2026/03/27 00:42:22 by csilva-s         ###   ########.fr       */
+/*   Created: 2026/04/12 21:00:00 by fconde-p          #+#    #+#             */
+/*   Updated: 2026/04/12 21:00:00 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../minishell.h"
 
-char	*get_env_value(char *name, t_shelly *shell)
+char	**get_env_array(t_shelly *shell)
 {
 	t_env	*curr;
+	int		count;
+	int		i;
+	char	**array;
 
-	if (!name || !shell || !shell->env_list)
-		return (NULL);
+	count = 0;
 	curr = shell->env_list;
 	while (curr)
 	{
-		if (ft_strncmp(curr->key, name, ft_strlen(name)) == 0 && \
-			curr->key[ft_strlen(name)] == '\0')
-			return (ft_strdup(curr->value));
+		count++;
 		curr = curr->next;
 	}
-	return (NULL);
+	array = malloc(sizeof(char *) * (count + 1));
+	if (!array)
+		return (NULL);
+	i = 0;
+	curr = shell->env_list;
+	while (curr)
+	{
+		array[i++] = ft_strjoin(curr->key, ft_strjoin("=", curr->value));
+		curr = curr->next;
+	}
+	array[i] = NULL;
+	return (array);
 }

--- a/src/utils/env_init.c
+++ b/src/utils/env_init.c
@@ -1,31 +1,39 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   env.c                                              :+:      :+:    :+:   */
+/*   env_init.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2026/04/09 20:40:19 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/09 21:45:53 by fconde-p         ###   ########.fr       */
+/*   Created: 2026/04/12 21:00:00 by fconde-p          #+#    #+#             */
+/*   Updated: 2026/04/12 21:00:00 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../minishell.h"
 
-int	ft_env(t_shelly *shelly)
+int	init_env_list(t_shelly *shell, char **envp)
 {
-	t_env	*curr;
+	int		i;
+	char	*str;
+	char	*eq;
 
-	if (!shelly || !shelly->env_list)
+	i = 0;
+	if (!shell || !envp)
 		return (0);
-	curr = shelly->env_list;
-	while (curr)
+	while (envp[i])
 	{
-		ft_putstr_fd(curr->key, 1);
-		ft_putstr_fd("=", 1);
-		ft_putstr_fd(curr->value ? curr->value : "", 1);
-		ft_putstr_fd("\n", 1);
-		curr = curr->next;
+		str = ft_strdup(envp[i]);
+		if (!str)
+			return (0);
+		eq = ft_strchr(str, '=');
+		if (eq)
+		{
+			*eq = '\0';
+			set_env_var(shell, str, eq + 1);
+		}
+		free(str);
+		i++;
 	}
-	return (0);
+	return (1);
 }

--- a/src/utils/env_set.c
+++ b/src/utils/env_set.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_set.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/12 21:00:00 by fconde-p          #+#    #+#             */
+/*   Updated: 2026/04/12 21:00:00 by fconde-p         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../minishell.h"
+
+int	set_env_var(t_shelly *shell, char *key, char *value)
+{
+	t_env	*curr;
+	t_env	*last;
+	t_env	*new_node;
+	size_t	len;
+
+	if (!shell || !key)
+		return (0);
+	len = ft_strlen(key);
+	curr = shell->env_list;
+	last = NULL;
+	while (curr)
+	{
+		if (ft_strlen(curr->key) == len && ft_strncmp(curr->key, key, len) == 0)
+		{
+			free(curr->value);
+			curr->value = ft_strdup(value ? value : "");
+			return (1);
+		}
+		last = curr;
+		curr = curr->next;
+	}
+	new_node = malloc(sizeof(t_env));
+	if (!new_node)
+		return (0);
+	new_node->key = ft_strdup(key);
+	new_node->value = ft_strdup(value ? value : "");
+	new_node->next = NULL;
+	if (!last)
+		shell->env_list = new_node;
+	else
+		last->next = new_node;
+	return (1);
+}

--- a/tests/makefile
+++ b/tests/makefile
@@ -24,6 +24,7 @@ C_FILES     = ../src/parsing/parser.c \
               ../src/parsing/fsm/clear_token_list.c \
               ../src/builtins/env.c \
               ../src/builtins/pwd.c \
+              ../src/builtins/cd.c \
 							../src/builtins/exit.c
 
 LIBS        = $(LIBFT) # -ldl -lglfw -pthread -lm
@@ -42,6 +43,7 @@ TEST_SRCS   = $(TEST_DIR)/test-parser.c \
 				$(TEST_DIR)/test-env.c \
 				$(TEST_DIR)/test-pwd.c \
 				$(TEST_DIR)/test-exit.c \
+				$(TEST_DIR)/test-cd.c \
 				$(TEST_DIR)/test-env_manager.c
 TEST_BINS   = $(TEST_SRCS:.c=.out)
 REPORT_LOG  = test_report.log

--- a/tests/makefile
+++ b/tests/makefile
@@ -18,6 +18,9 @@ C_FILES     = ../src/parsing/parser.c \
               ../src/execution/heredoc.c \
               ../src/utils/get_env_value.c \
               ../src/utils/cleanup.c \
+              ../src/utils/env_set.c \
+              ../src/utils/env_init.c \
+              ../src/utils/env_array.c \
               ../src/parsing/fsm/clear_token_list.c \
               ../src/builtins/env.c \
               ../src/builtins/pwd.c \
@@ -38,7 +41,8 @@ TEST_SRCS   = $(TEST_DIR)/test-parser.c \
 				$(TEST_DIR)/test-clear_token_list.c \
 				$(TEST_DIR)/test-env.c \
 				$(TEST_DIR)/test-pwd.c \
-				$(TEST_DIR)/test-exit.c
+				$(TEST_DIR)/test-exit.c \
+				$(TEST_DIR)/test-env_manager.c
 TEST_BINS   = $(TEST_SRCS:.c=.out)
 REPORT_LOG  = test_report.log
 

--- a/tests/makefile
+++ b/tests/makefile
@@ -20,7 +20,8 @@ C_FILES     = ../src/parsing/parser.c \
               ../src/utils/cleanup.c \
               ../src/parsing/fsm/clear_token_list.c \
               ../src/builtins/env.c \
-              ../src/builtins/pwd.c
+              ../src/builtins/pwd.c \
+							../src/builtins/exit.c
 
 LIBS        = $(LIBFT) # -ldl -lglfw -pthread -lm
 HEADERS     = -I. -I$(LIBFT_DIR) -I$(TEST_DIR) -I..

--- a/tests/makefile
+++ b/tests/makefile
@@ -37,7 +37,8 @@ TEST_SRCS   = $(TEST_DIR)/test-parser.c \
 				$(TEST_DIR)/test-pipe.c \
 				$(TEST_DIR)/test-clear_token_list.c \
 				$(TEST_DIR)/test-env.c \
-				$(TEST_DIR)/test-pwd.c
+				$(TEST_DIR)/test-pwd.c \
+				$(TEST_DIR)/test-exit.c
 TEST_BINS   = $(TEST_SRCS:.c=.out)
 REPORT_LOG  = test_report.log
 

--- a/tests/test-cd.c
+++ b/tests/test-cd.c
@@ -1,0 +1,152 @@
+#include "./tests.h"
+#include "../minishell.h"
+
+static void	clear_env_list(t_env **list)
+{
+	t_env	*curr;
+	t_env	*next;
+
+	while (*list)
+	{
+		curr = *list;
+		next = curr->next;
+		free(curr->key);
+		free(curr->value);
+		free(curr);
+		*list = next;
+	}
+	*list = NULL;
+}
+
+int	test_cd_absolute_path(void)
+{
+	t_shelly	shell = {0};
+	char		*args[] = {"cd", "/tmp", NULL};
+	char		*pwd;
+	int			res;
+
+	res = ft_cd(args, &shell);
+	pwd = get_env_value("PWD", &shell);
+	if (res != 0 || !pwd || ft_strncmp(pwd, "/tmp", 5) != 0)
+	{
+		free(pwd);
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	free(pwd);
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	test_cd_home(void)
+{
+	t_shelly	shell = {0};
+	char		*args[] = {"cd", NULL};
+	char		*pwd;
+	char		*home;
+	int			res;
+
+	home = getenv("HOME");
+	set_env_var(&shell, "HOME", home);
+	res = ft_cd(args, &shell);
+	pwd = get_env_value("PWD", &shell);
+	if (res != 0 || !pwd || ft_strncmp(pwd, home, ft_strlen(home) + 1) != 0)
+	{
+		free(pwd);
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	free(pwd);
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	test_cd_minus(void)
+{
+	t_shelly	shell = {0};
+	char		*args1[] = {"cd", "/tmp", NULL};
+	char		*args2[] = {"cd", "/", NULL};
+	char		*args3[] = {"cd", "-", NULL};
+	char		*pwd;
+	int			res;
+
+	ft_cd(args1, &shell);
+	ft_cd(args2, &shell);
+	res = ft_cd(args3, &shell);
+	pwd = get_env_value("PWD", &shell);
+	if (res != 0 || !pwd || ft_strncmp(pwd, "/tmp", 5) != 0)
+	{
+		free(pwd);
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	free(pwd);
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	test_cd_tilde(void)
+{
+	t_shelly	shell = {0};
+	char		*args[] = {"cd", "~", NULL};
+	char		*pwd;
+	char		*home;
+	int			res;
+
+	home = getenv("HOME");
+	set_env_var(&shell, "HOME", home);
+	res = ft_cd(args, &shell);
+	pwd = get_env_value("PWD", &shell);
+	if (res != 0 || !pwd || ft_strncmp(pwd, home, ft_strlen(home) + 1) != 0)
+	{
+		free(pwd);
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	free(pwd);
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	test_cd_too_many_args(void)
+{
+	t_shelly	shell = {0};
+	char		*args[] = {"cd", "/tmp", "/var", NULL};
+	int			res;
+
+	res = ft_cd(args, &shell);
+	if (res == 0)
+	{
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	test_cd_home_unset(void)
+{
+	t_shelly	shell = {0};
+	char		*args[] = {"cd", NULL};
+	int			res;
+
+	res = ft_cd(args, &shell);
+	if (res == 0)
+	{
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	main(void)
+{
+	RUN_TEST(test_cd_absolute_path);
+	RUN_TEST(test_cd_home);
+	RUN_TEST(test_cd_home_unset);
+	RUN_TEST(test_cd_minus);
+	RUN_TEST(test_cd_tilde);
+	RUN_TEST(test_cd_too_many_args);
+	return (0);
+}

--- a/tests/test-env.c
+++ b/tests/test-env.c
@@ -31,11 +31,11 @@ static char	*capture_env_output(t_shelly shell)
 
 int	should_print_provided_envp(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char	*envp[] = {"VAR1=VAL1", "VAR2=VAL2", NULL};
 	char	*out;
 
-	shell.envp = envp;
+	init_env_list(&shell, envp);
 	out = capture_env_output(shell);
 	if (!out)
 		return (EXIT_FAILURE);
@@ -46,10 +46,9 @@ int	should_print_provided_envp(void)
 
 int	should_handle_null_envp(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char	*out;
 
-	shell.envp = NULL;
 	out = capture_env_output(shell);
 	if (out != NULL)
 		return (EXIT_FAILURE);
@@ -58,11 +57,11 @@ int	should_handle_null_envp(void)
 
 int	should_handle_empty_envp(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char	*envp[] = {NULL};
 	char	*out;
 
-	shell.envp = envp;
+	init_env_list(&shell, envp);
 	out = capture_env_output(shell);
 	if (out != NULL)
 		return (EXIT_FAILURE);

--- a/tests/test-env.c
+++ b/tests/test-env.c
@@ -14,7 +14,7 @@ static char	*capture_env_output(t_shelly shell)
 	saved_stdout = dup(STDOUT_FILENO);
 	dup2(fd, STDOUT_FILENO);
 	close(fd);
-	ft_env(shell);
+	ft_env(&shell);
 	dup2(saved_stdout, STDOUT_FILENO);
 	close(saved_stdout);
 	fd = open("/tmp/.test_env_out", O_RDONLY);

--- a/tests/test-env_manager.c
+++ b/tests/test-env_manager.c
@@ -1,0 +1,79 @@
+#include "./tests.h"
+#include "../minishell.h"
+
+static void	clear_env_list(t_env **list)
+{
+	t_env	*curr;
+	t_env	*next;
+
+	while (*list)
+	{
+		curr = *list;
+		next = curr->next;
+		free(curr->key);
+		free(curr->value);
+		free(curr);
+		*list = next;
+	}
+}
+
+int	should_add_new_variable(void)
+{
+	t_shelly	shell = {0};
+	t_env	*curr;
+
+	if (!set_env_var(&shell, "TEST_VAR", "Hello"))
+		return (EXIT_FAILURE);
+	curr = shell.env_list;
+	if (!curr || ft_strncmp(curr->key, "TEST_VAR", 8) != 0 
+		|| ft_strncmp(curr->value, "Hello", 5) != 0)
+	{
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	should_update_existing_variable(void)
+{
+	t_shelly	shell = {0};
+	t_env	*curr;
+
+	set_env_var(&shell, "TEST_VAR", "OldValue");
+	if (!set_env_var(&shell, "TEST_VAR", "NewValue"))
+		return (EXIT_FAILURE);
+	curr = shell.env_list;
+	if (ft_strncmp(curr->value, "NewValue", 8) != 0)
+	{
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	should_handle_null_value_as_empty_string(void)
+{
+	t_shelly	shell = {0};
+	t_env	*curr;
+
+	if (!set_env_var(&shell, "EMPTY_VAR", NULL))
+		return (EXIT_FAILURE);
+	curr = shell.env_list;
+	if (curr->value[0] != '\0')
+	{
+		clear_env_list(&shell.env_list);
+		return (EXIT_FAILURE);
+	}
+	clear_env_list(&shell.env_list);
+	return (EXIT_SUCCESS);
+}
+
+int	main(void)
+{
+	RUN_TEST(should_add_new_variable);
+	RUN_TEST(should_update_existing_variable);
+	RUN_TEST(should_handle_null_value_as_empty_string);
+	return (0);
+}

--- a/tests/test-executor.c
+++ b/tests/test-executor.c
@@ -106,12 +106,12 @@ int	should_return_full_path_when_cmd_is_absolute(void)
 
 int	should_return_zero_on_successful_command(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	t_ast_node	*node;
 	char		*args[] = {"ls", NULL};
 	int			status;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_TRUE;
 	node = make_cmd_node(args);
@@ -121,12 +121,12 @@ int	should_return_zero_on_successful_command(void)
 
 int	should_return_nonzero_on_failed_command(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	t_ast_node	*node;
 	char		*args[] = {"ls", "/this/path/does/not/exist/xyz", NULL};
 	int			status;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_TRUE;
 	node = make_cmd_node(args);
@@ -136,12 +136,12 @@ int	should_return_nonzero_on_failed_command(void)
 
 int	should_return_nonzero_for_missing_command(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	t_ast_node	*node;
 	char		*args[] = {"this_cmd_does_not_exist_xyz123", NULL};
 	int			status;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_TRUE;
 	node = make_cmd_node(args);

--- a/tests/test-executor.c
+++ b/tests/test-executor.c
@@ -19,10 +19,12 @@ static t_ast_node	*make_cmd_node(char **args)
 
 int	should_find_path_from_envp(void)
 {
+	t_shelly	shell = {0};
 	char	*envp[] = {"PATH=/usr/bin:/bin", NULL};
 	char	**paths;
 
-	paths = find_path(envp);
+	init_env_list(&shell, envp);
+	paths = find_path(&shell);
 	if (!paths || !paths[0])
 		return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
@@ -30,10 +32,12 @@ int	should_find_path_from_envp(void)
 
 int	should_find_path_when_not_first_entry(void)
 {
+	t_shelly	shell = {0};
 	char	*envp[] = {"HOME=/home/user", "PATH=/usr/bin:/bin", NULL};
 	char	**paths;
 
-	paths = find_path(envp);
+	init_env_list(&shell, envp);
+	paths = find_path(&shell);
 	if (!paths || !paths[0])
 		return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
@@ -41,10 +45,12 @@ int	should_find_path_when_not_first_entry(void)
 
 int	should_return_null_when_no_path_in_envp(void)
 {
+	t_shelly	shell = {0};
 	char	*envp[] = {"HOME=/home/user", "USER=tester", NULL};
 	char	**paths;
 
-	paths = find_path(envp);
+	init_env_list(&shell, envp);
+	paths = find_path(&shell);
 	if (paths != NULL)
 		return (EXIT_FAILURE);
 	return (EXIT_SUCCESS);
@@ -52,10 +58,12 @@ int	should_return_null_when_no_path_in_envp(void)
 
 int	should_split_path_entries_correctly(void)
 {
+	t_shelly	shell = {0};
 	char	*envp[] = {"PATH=/usr/bin:/bin", NULL};
 	char	**paths;
 
-	paths = find_path(envp);
+	init_env_list(&shell, envp);
+	paths = find_path(&shell);
 	if (!paths || !paths[0] || !paths[1])
 		return (EXIT_FAILURE);
 	if (ft_strncmp(paths[0], "/usr/bin", 8) != 0)

--- a/tests/test-exit.c
+++ b/tests/test-exit.c
@@ -3,12 +3,11 @@
 
 static int	run_exit_test(char **args, int expected_status, int initial_last_status)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	pid_t		pid;
 	int			status;
 
 	shell.last_exit_status = initial_last_status;
-	shell.envp = NULL;
 	pid = fork();
 	if (pid == 0)
 	{

--- a/tests/test-exit.c
+++ b/tests/test-exit.c
@@ -13,7 +13,7 @@ static int	run_exit_test(char **args, int expected_status, int initial_last_stat
 	if (pid == 0)
 	{
 		ft_exit(&shell, args);
-		exit(0); // Should not reach here
+		exit((expected_status + 1) & 255); // Fallback: must differ from expected_status
 	}
 	waitpid(pid, &status, 0);
 	if (WIFEXITED(status))

--- a/tests/test-exit.c
+++ b/tests/test-exit.c
@@ -1,0 +1,79 @@
+#include "./tests.h"
+#include "../minishell.h"
+
+static int	run_exit_test(char **args, int expected_status, int initial_last_status)
+{
+	t_shelly	shell;
+	pid_t		pid;
+	int			status;
+
+	shell.last_exit_status = initial_last_status;
+	shell.envp = NULL;
+	pid = fork();
+	if (pid == 0)
+	{
+		ft_exit(&shell, args);
+		exit(0); // Should not reach here
+	}
+	waitpid(pid, &status, 0);
+	if (WIFEXITED(status))
+	{
+		if (WEXITSTATUS(status) == expected_status)
+			return (EXIT_SUCCESS);
+	}
+	return (EXIT_FAILURE);
+}
+
+int	should_exit_with_last_status_when_no_args(void)
+{
+	char	*args[] = {"exit", NULL};
+
+	return (run_exit_test(args, 42, 42));
+}
+
+int	should_exit_with_zero_when_arg_is_0(void)
+{
+	char	*args[] = {"exit", "0", NULL};
+
+	return (run_exit_test(args, 0, 0));
+}
+
+int	should_exit_with_provided_value(void)
+{
+	char	*args[] = {"exit", "42", NULL};
+
+	return (run_exit_test(args, 42, 0));
+}
+
+int	should_exit_with_truncated_value(void)
+{
+	// 257 & 255 = 1
+	char	*args[] = {"exit", "257", NULL};
+
+	return (run_exit_test(args, 1, 0));
+}
+
+int	should_exit_with_255_on_non_numeric_arg(void)
+{
+	char	*args[] = {"exit", "abc", NULL};
+
+	return (run_exit_test(args, 255, 0));
+}
+
+int	should_exit_with_255_on_too_many_args(void)
+{
+	char	*args[] = {"exit", "1", "2", NULL};
+
+	return (run_exit_test(args, 255, 0));
+}
+
+int	main(void)
+{
+	RUN_TEST(should_exit_with_last_status_when_no_args);
+	RUN_TEST(should_exit_with_zero_when_arg_is_0);
+	RUN_TEST(should_exit_with_provided_value);
+	RUN_TEST(should_exit_with_truncated_value);
+	RUN_TEST(should_exit_with_255_on_non_numeric_arg);
+	RUN_TEST(should_exit_with_255_on_too_many_args);
+	return (0);
+}

--- a/tests/test-expander.c
+++ b/tests/test-expander.c
@@ -4,10 +4,10 @@
 int	should_expand_tilde_to_home(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"HOME=/home/dot", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("~");
 	if (!token)
@@ -28,10 +28,10 @@ int	should_expand_tilde_to_home(void)
 int	should_not_expand_tilde_if_no_home_set(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("~");
 	if (!token)
@@ -52,10 +52,10 @@ int	should_not_expand_tilde_if_no_home_set(void)
 int	should_expand_variable(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("$VAR");
 	if (!token)
@@ -76,10 +76,10 @@ int	should_expand_variable(void)
 int	should_expand_variable_with_nested_quotes(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("\"\'$VAR\'\"");
 	if (!token)
@@ -100,10 +100,10 @@ int	should_expand_variable_with_nested_quotes(void)
 int	should_expand_exit_status(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 42;
 	token = set_tokens("$?");
 	if (!token)
@@ -124,10 +124,10 @@ int	should_expand_exit_status(void)
 int	should_remove_double_quotes(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("\"hello\"");
 	if (!token)
@@ -148,10 +148,10 @@ int	should_remove_double_quotes(void)
 int	should_remove_single_quotes(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("'hello'");
 	if (!token)
@@ -172,10 +172,10 @@ int	should_remove_single_quotes(void)
 int	should_not_expand_in_single_quotes(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	// When set_tokens parses '$VAR', it sees it as a word but with quotes.
 	// Actually, set_tokens doesn't set 'quoted' flag yet properly.
@@ -199,10 +199,10 @@ int	should_not_expand_in_single_quotes(void)
 int	should_expand_in_double_quotes(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("\"$VAR\"");
 	if (!token)
@@ -223,10 +223,10 @@ int	should_expand_in_double_quotes(void)
 int	should_split_words_if_not_quoted(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello world", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("$VAR");
 	if (!token)
@@ -250,10 +250,10 @@ int	should_split_words_if_not_quoted(void)
 int	should_not_split_words_if_quoted(void)
 {
 	t_token	*token = NULL;
-	t_shelly shelly;
+	t_shelly shelly = {0};
 	char *envp[] = {"VAR=hello world", NULL};
 
-	shelly.envp = envp;
+	init_env_list(&shelly, envp);
 	shelly.last_exit_status = 0;
 	token = set_tokens("\"$VAR\"");
 	if (!token)

--- a/tests/test-pipe.c
+++ b/tests/test-pipe.c
@@ -64,12 +64,12 @@ static char	*capture_output(t_ast_node *ast, t_shelly shell)
 */
 int	should_pipe_echo_to_cat(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char		*args_l[] = {"echo", "hello", NULL};
 	char		*args_r[] = {"cat", NULL};
 	char		*out;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_FALSE;
 	out = capture_output(
@@ -87,14 +87,14 @@ int	should_pipe_echo_to_cat(void)
 */
 int	should_chain_three_commands(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char		*a_echo[] = {"echo", "hello", NULL};
 	char		*a_cat1[] = {"cat", NULL};
 	char		*a_cat2[] = {"cat", NULL};
 	t_ast_node	*inner_pipe;
 	char		*out;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_FALSE;
 	inner_pipe = make_pipe_node(make_cmd_node(a_cat1), make_cmd_node(a_cat2));
@@ -113,12 +113,12 @@ int	should_chain_three_commands(void)
 */
 int	should_pipe_echo_to_grep_match(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char		*args_l[] = {"echo", "hello", NULL};
 	char		*args_r[] = {"grep", "hello", NULL};
 	char		*out;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_FALSE;
 	out = capture_output(
@@ -136,12 +136,12 @@ int	should_pipe_echo_to_grep_match(void)
 */
 int	should_pipe_grep_no_match_produces_no_output(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char		*args_l[] = {"echo", "hello", NULL};
 	char		*args_r[] = {"grep", "nope", NULL};
 	char		*out;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_FALSE;
 	out = capture_output(
@@ -157,12 +157,12 @@ int	should_pipe_grep_no_match_produces_no_output(void)
 */
 int	should_pipe_echo_n_no_newline(void)
 {
-	t_shelly	shell;
+	t_shelly	shell = {0};
 	char		*args_l[] = {"echo", "-n", "hello", NULL};
 	char		*args_r[] = {"cat", NULL};
 	char		*out;
 
-	shell.envp = environ;
+	init_env_list(&shell, environ);
 	shell.last_exit_status = 0;
 	shell.suppress_output = BOOL_FALSE;
 	out = capture_output(


### PR DESCRIPTION
### Implementa builtin function exit() e testes unitários mínimos.

- Foi ajustado um ponto no executor() na função auxiliar execute_builtin() onde passamos a enviar o ponteiro de t_shelly em vez de seu valor. Isso é necessário para atualizar o valor de last_exit_status (char).

### Implementa builtin function cd()

- Inclui funções em /utils para gestão de lista de variáveis de ambiente (env).

### Observação

- Os testes unitários estão passando, mas é necessário sempre validar testes funcionais manualmente enquanto não temos essa implementação no framework de testes.