### PR TITLE
Norm get token len

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+         #
+#    By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/01/01 00:00:00 by csilva-s          #+#    #+#              #
-#    Updated: 2026/04/16 01:38:53 by csilva-s         ###   ########.fr        #
+#    Updated: 2026/05/02 19:30:07 by fconde-p         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -31,6 +31,7 @@ SRC_FILES	= main.c \
 			  parsing/expander/tilde_expansion.c \
 			  parsing/expander/token_insertion.c \
 			  parsing/fsm/get_token_len.c \
+			  parsing/fsm/check_assignment_operator.c \
 			  parsing/fsm/clear_token_list.c \
 			  parsing/fsm/set_tokens.c \
 			  execution/executor.c \

--- a/minishell.h
+++ b/minishell.h
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
+/*                                                                            */
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
-/*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/12/29 16:55:46 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/21 19:22:16 by csilva-s         ###   ########.fr       */
+/*   Updated: 2026/05/02 19:31:22 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,6 +96,7 @@ typedef struct s_ast_node
 // lexer functions
 t_token		*set_tokens(char *s);
 int			get_token_len(char *str);
+int			check_assignment_operator(char *str, int i);
 void		clear_token_list(t_token **head);
 
 // expander functions

--- a/src/parsing/fsm/check_assignment_operator.c
+++ b/src/parsing/fsm/check_assignment_operator.c
@@ -1,0 +1,29 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   check_assignment_operator.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/05/02 19:09:55 by fconde-p          #+#    #+#             */
+/*   Updated: 2026/05/02 19:10:20 by fconde-p         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../../minishell.h"
+
+int	check_assignment_operator(char *str, int i)
+{
+	int	has_eq;
+	int	j;
+
+	has_eq = 0;
+	j = 0;
+	while (str[j] && j < i)
+	{
+		if (str[j] == '=')
+			has_eq = 1;
+		j++;
+	}
+	return (has_eq);
+}

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/01 17:40:52 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/01 18:01:20 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,23 @@ static int	handle_quotes_len(char *str)
 	return (i);
 }
 
+static int	handle_operator_len(char *str)
+{
+	int	i;
+
+	i = 0;
+	if (str[0] == '|')
+		return (1);
+	else if (str[0] == '<' && str[1] == '<')
+		return (2);
+	else if (str[0] == '>' && str[1] == '>')
+		return (2);
+	else if (str[0] == '<' || str[0] == '>')
+		return (1);
+	else
+		return (-1);
+}
+
 int	get_token_len(char *str)
 {
 	int		i;
@@ -43,12 +60,9 @@ int	get_token_len(char *str)
 
 	i = 0;
 	if (str[i] == '\'' || str[i] == '\"')
-	{
 		return (handle_quotes_len(&str[i]));
-	}
-	if ((str[i] == '<' && str[i + 1] == '<')
-		|| (str[i] == '>' && str[i + 1] == '>'))
-		return (2);
+	if (str[i] == '<' || str[i] == '>' || str[i] == '|')
+		return (handle_operator_len(&str[i]));
 	while (str[i] != '\0')
 	{
 		if (str[i] == '\'' || str[i] == '\"')

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/02 19:08:04 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/02 19:10:31 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,21 +53,21 @@ static int	handle_operator_len(char *str)
 		return (-1);
 }
 
-static int	check_assignment_operator(char *str, int i)
-{
-	int	has_eq;
-	int	j;
+// static int	check_assignment_operator(char *str, int i)
+// {
+// 	int	has_eq;
+// 	int	j;
 
-	has_eq = 0;
-	j = 0;
-	while (str[j] && j < i)
-	{
-		if (str[j] == '=')
-			has_eq = 1;
-		j++;
-	}
-	return (has_eq);
-}
+// 	has_eq = 0;
+// 	j = 0;
+// 	while (str[j] && j < i)
+// 	{
+// 		if (str[j] == '=')
+// 			has_eq = 1;
+// 		j++;
+// 	}
+// 	return (has_eq);
+// }
 
 static int	deal_with_quote(char *str, int i)
 {

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/02 19:10:31 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/02 19:49:56 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,9 +38,6 @@ static int	handle_quotes_len(char *str)
 
 static int	handle_operator_len(char *str)
 {
-	int	i;
-
-	i = 0;
 	if (str[0] == '|')
 		return (1);
 	else if (str[0] == '<' && str[1] == '<')

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/01 18:01:20 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/01 20:02:06 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,11 @@ static int	handle_operator_len(char *str)
 		return (-1);
 }
 
+static int	has_assignment_operator(char *str, int i)
+{
+
+}
+
 int	get_token_len(char *str)
 {
 	int		i;
@@ -63,31 +68,12 @@ int	get_token_len(char *str)
 		return (handle_quotes_len(&str[i]));
 	if (str[i] == '<' || str[i] == '>' || str[i] == '|')
 		return (handle_operator_len(&str[i]));
-	while (str[i] != '\0')
+	while (str[i] != '\0' && !is_token_delimiter(str[i]))
 	{
-		if (str[i] == '\'' || str[i] == '\"')
+		if ((str[i] == '\'' || str[i] == '\"') 
+			&& has_assignment_operator(&str, i))
 		{
-			int	has_eq;
-			int	j;
-
-			has_eq = 0;
-			j = 0;
-			while (str[j] && j < i)
-			{
-				if (str[j] == '=')
-					has_eq = 1;
-				j++;
-			}
-			if (has_eq)
-			{
-				quote = str[i];
-				i++;
-				while (str[i] != '\0' && str[i] != quote)
-					i++;
-				if (str[i] == quote)
-					i++;
-				continue ;
-			}
+			i += handle_quotes_len(&str[i]);
 		}
 		if (is_token_delimiter(str[i]) == EXIT_SUCCESS)
 			break ;

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   get_token_len.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/04/26 23:04:41 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/01 17:10:33 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,15 +37,18 @@ int	get_token_len(char *str)
 			i++;
 		return (i);
 	}
-	if ((str[i] == '<' && str[i + 1] == '<') 
+	if ((str[i] == '<' && str[i + 1] == '<')
 		|| (str[i] == '>' && str[i + 1] == '>'))
 		return (2);
 	while (str[i] != '\0')
 	{
 		if (str[i] == '\'' || str[i] == '\"')
 		{
-			int	has_eq = 0;
-			int	j = 0;
+			int	has_eq;
+			int	j;
+
+			has_eq = 0;
+			j = 0;
 			while (str[j] && j < i)
 			{
 				if (str[j] == '=')

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/01 18:01:20 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/02 18:25:11 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,22 @@ static int	handle_operator_len(char *str)
 		return (-1);
 }
 
+static int	check_attribuition_operator(char *str, int i)
+{
+	int	has_eq;
+	int	j;
+
+	has_eq = 0;
+	j = 0;
+	while (str[j] && j < i)
+	{
+		if (str[j] == '=')
+			has_eq = 1;
+		j++;
+	}
+	return (has_eq);
+}
+
 int	get_token_len(char *str)
 {
 	int		i;
@@ -67,18 +83,7 @@ int	get_token_len(char *str)
 	{
 		if (str[i] == '\'' || str[i] == '\"')
 		{
-			int	has_eq;
-			int	j;
-
-			has_eq = 0;
-			j = 0;
-			while (str[j] && j < i)
-			{
-				if (str[j] == '=')
-					has_eq = 1;
-				j++;
-			}
-			if (has_eq)
+			if (check_attribuition_operator(str, i))
 			{
 				quote = str[i];
 				i++;

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/01 17:10:33 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/01 17:40:52 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,21 @@ static int	is_token_delimiter(char c)
 	return (EXIT_FAILURE);
 }
 
+static int	handle_quotes_len(char *str)
+{
+	int		i;
+	char	quote;
+
+	i = 0;
+	quote = str[i];
+	i++;
+	while (str[i] != '\0' && str[i] != quote)
+		i++;
+	if (str[i] == quote)
+		i++;
+	return (i);
+}
+
 int	get_token_len(char *str)
 {
 	int		i;
@@ -29,13 +44,7 @@ int	get_token_len(char *str)
 	i = 0;
 	if (str[i] == '\'' || str[i] == '\"')
 	{
-		quote = str[i];
-		i++;
-		while (str[i] != '\0' && str[i] != quote)
-			i++;
-		if (str[i] == quote)
-			i++;
-		return (i);
+		return (handle_quotes_len(&str[i]));
 	}
 	if ((str[i] == '<' && str[i + 1] == '<')
 		|| (str[i] == '>' && str[i + 1] == '>'))

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/01 20:02:06 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/01 18:01:20 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,11 +53,6 @@ static int	handle_operator_len(char *str)
 		return (-1);
 }
 
-static int	has_assignment_operator(char *str, int i)
-{
-
-}
-
 int	get_token_len(char *str)
 {
 	int		i;
@@ -68,12 +63,31 @@ int	get_token_len(char *str)
 		return (handle_quotes_len(&str[i]));
 	if (str[i] == '<' || str[i] == '>' || str[i] == '|')
 		return (handle_operator_len(&str[i]));
-	while (str[i] != '\0' && !is_token_delimiter(str[i]))
+	while (str[i] != '\0')
 	{
-		if ((str[i] == '\'' || str[i] == '\"') 
-			&& has_assignment_operator(&str, i))
+		if (str[i] == '\'' || str[i] == '\"')
 		{
-			i += handle_quotes_len(&str[i]);
+			int	has_eq;
+			int	j;
+
+			has_eq = 0;
+			j = 0;
+			while (str[j] && j < i)
+			{
+				if (str[j] == '=')
+					has_eq = 1;
+				j++;
+			}
+			if (has_eq)
+			{
+				quote = str[i];
+				i++;
+				while (str[i] != '\0' && str[i] != quote)
+					i++;
+				if (str[i] == quote)
+					i++;
+				continue ;
+			}
 		}
 		if (is_token_delimiter(str[i]) == EXIT_SUCCESS)
 			break ;

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/02 18:25:11 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/02 19:08:04 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ static int	handle_operator_len(char *str)
 		return (-1);
 }
 
-static int	check_attribuition_operator(char *str, int i)
+static int	check_assignment_operator(char *str, int i)
 {
 	int	has_eq;
 	int	j;
@@ -69,10 +69,22 @@ static int	check_attribuition_operator(char *str, int i)
 	return (has_eq);
 }
 
+static int	deal_with_quote(char *str, int i)
+{
+	char	quote;
+
+	quote = str[i];
+	i++;
+	while (str[i] != '\0' && str[i] != quote)
+		i++;
+	if (str[i] == quote)
+		i++;
+	return (i);
+}
+
 int	get_token_len(char *str)
 {
 	int		i;
-	char	quote;
 
 	i = 0;
 	if (str[i] == '\'' || str[i] == '\"')
@@ -83,16 +95,8 @@ int	get_token_len(char *str)
 	{
 		if (str[i] == '\'' || str[i] == '\"')
 		{
-			if (check_attribuition_operator(str, i))
-			{
-				quote = str[i];
-				i++;
-				while (str[i] != '\0' && str[i] != quote)
-					i++;
-				if (str[i] == quote)
-					i++;
-				continue ;
-			}
+			if (check_assignment_operator(str, i))
+				i = deal_with_quote(str, i);
 		}
 		if (is_token_delimiter(str[i]) == EXIT_SUCCESS)
 			break ;

--- a/src/parsing/fsm/get_token_len.c
+++ b/src/parsing/fsm/get_token_len.c
@@ -6,7 +6,7 @@
 /*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/02/21 18:25:25 by fconde-p          #+#    #+#             */
-/*   Updated: 2026/05/02 19:49:56 by fconde-p         ###   ########.fr       */
+/*   Updated: 2026/05/02 19:52:01 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,22 +49,6 @@ static int	handle_operator_len(char *str)
 	else
 		return (-1);
 }
-
-// static int	check_assignment_operator(char *str, int i)
-// {
-// 	int	has_eq;
-// 	int	j;
-
-// 	has_eq = 0;
-// 	j = 0;
-// 	while (str[j] && j < i)
-// 	{
-// 		if (str[j] == '=')
-// 			has_eq = 1;
-// 		j++;
-// 	}
-// 	return (has_eq);
-// }
 
 static int	deal_with_quote(char *str, int i)
 {

--- a/tests/makefile
+++ b/tests/makefile
@@ -12,6 +12,7 @@ C_FILES     = ../src/parsing/parser.c \
               ../src/parsing/expander/token_insertion.c \
               ../src/parsing/fsm/set_tokens.c \
               ../src/parsing/fsm/get_token_len.c \
+              ../src/parsing/fsm/check_assignment_operator.c \
               ../src/execution/redirections.c \
               ../src/execution/executor.c \
               ../src/execution/executor_utils.c \


### PR DESCRIPTION
"tá chovendo pica e o meu c# é guarda-chuvas" (Fernando Pessoa)

Dito isso, o presente commit propõe:

- ajustes no get_token_len() para fazer adequadamente o _export_ de variáveis de ambiente contendo mais de uma palavra (CT: `export TEST="nome composto por mais de uma palavra"`);
- Refatoração para atender à norminette;
- Aplica mudanças ao longo do projeto e no framework de testes unitários;