### PR TITLE
fix:comportamento unset PATH

### DIFF
--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fconde-p <fconde-p@student.42.fr>          +#+  +:+       +#+        */
+/*   By: fconde-p <fconde-p@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/21 23:38:29 by csilva-s          #+#    #+#             */
-/*   Updated: 2026/04/23 22:38:12 by csilva-s         ###   ########.fr       */
+/*   Updated: 2026/05/03 14:00:53 by fconde-p         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ char	*search_cmd_path(char *cmd, t_shelly *shelly)
 
 char	*find_command(t_shelly *shelly, char *cmd)
 {
-	char	*command;
+	char	*full_command;
 
 	if (ft_strchr(cmd, '/'))
 	{
@@ -50,10 +50,13 @@ char	*find_command(t_shelly *shelly, char *cmd)
 			return (ft_strdup(cmd));
 		return (NULL);
 	}
-	command = search_cmd_path(cmd, shelly);
-	if (!command)
+	full_command = search_cmd_path(cmd, shelly);
+	if (!full_command)
+	{
+		printf("%s: No such file or directory\n", cmd);
 		return (NULL);
-	return (command);
+	}
+	return (full_command);
 }
 
 void	simple_command_routine(t_ast_node *ast, char *command_line,


### PR DESCRIPTION
## FIX

Agora o sistema retorna uma mensagem dizendo que o caminho do comando não foi encontrado (mesmo comportamento do bash).

*_arquivo dentro da norma42;_

Bash
<img width="564" height="48" alt="image" src="https://github.com/user-attachments/assets/7bfee9cd-b0ca-4768-bab0-bc3bd0c0fdca" />

Shelly
<img width="273" height="43" alt="image" src="https://github.com/user-attachments/assets/46c70668-d1da-4efd-aad0-86999489842a" />

Chupa essa manga, paizão!
