### PR TITLE
fix: Resolve o bug do não funcionamento dos redirects

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -121,6 +121,7 @@ int			exec_simple_command(t_ast_node *ast, t_shelly *shelly);
 void		simple_command_routine(t_ast_node *ast, char *command_line,
 				char **envp, int here_doc);
 int			execute_builtin(char *cmd, char **args, t_shelly *shelly);
+int			is_builtin(char *cmd);
 char		*search_cmd_path(char *cmd, t_shelly *shelly);
 int			handle_error(char *command_line, int heredoc);
 int			get_status_code(pid_t pid);

--- a/src/execution/execute_builtin.c
+++ b/src/execution/execute_builtin.c
@@ -12,6 +12,25 @@
 
 #include "../../minishell.h"
 
+int	is_builtin(char *cmd)
+{
+	if (ft_strncmp(cmd, "env", 3) == 0 && cmd[3] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "pwd", 3) == 0 && cmd[3] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "cd", 2) == 0 && cmd[2] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "exit", 4) == 0 && cmd[4] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "export", 6) == 0 && cmd[6] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "unset", 5) == 0 && cmd[5] == '\0')
+		return (1);
+	if (ft_strncmp(cmd, "echo", 4) == 0 && cmd[4] == '\0')
+		return (1);
+	return (0);
+}
+
 int	execute_builtin(char *cmd, char **args, t_shelly *shelly)
 {
 	if (!cmd)

--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -78,11 +78,23 @@ int	exec_simple_command(t_ast_node *ast, t_shelly *shelly)
 {
 	pid_t	pid;
 	int		builtin_ret;
+	int		saved_stdin;
+	int		saved_stdout;
 
-	builtin_ret = execute_builtin(ast->value.command->cmd[0],
-			ast->value.command->cmd, shelly);
-	if (builtin_ret != -1)
+	if (is_builtin(ast->value.command->cmd[0]))
+	{
+		saved_stdin = dup(1);
+		saved_stdout = dup(0);
+		if (ast->value.command->redir != NULL)
+			setup_redirections(ast->value.command->redir);
+		builtin_ret = execute_builtin(ast->value.command->cmd[0],
+				ast->value.command->cmd, shelly);
+		dup2(saved_stdin, STDIN_FILENO);
+		dup2(saved_stdout, STDOUT_FILENO);
+		close(saved_stdin);
+		close(saved_stdout);
 		return (builtin_ret);
+	}
 	pid = fork();
 	if (pid == 0)
 		exec_command_in_child(ast, shelly);

--- a/src/utils/has_meaningful_content.c
+++ b/src/utils/has_meaningful_content.c
@@ -27,7 +27,7 @@ static int	has_only_invisible_chars(char *line)
 	return (EXIT_SUCCESS);
 }
 
-int		has_meaningful_content(char *line)
+int	has_meaningful_content(char *line)
 {
 	if (line[0] == '\0')
 		return (EXIT_FAILURE);


### PR DESCRIPTION
Foi criada uma função chamada is_builtin que retorna  0 caso o comando enviado não seja um builtin. O motivo da criação dela foi para o desenvolvimento do fluxo quando o comando é um builtin. No fluxo anterior, a execute_builtin executava o comando sem fazer o setup dos redirects e o backup dos fds (in e out), fazendo com o que o resultado da execução sempre fosse lançado na saida padrão. No fluxo atual, antes de tudo, a execute_simple_command checa se é um builtin, fazendo toda a configuração de fds antes de executa-lo de fato.