### PR TITLE
Bug/redirout sem conteúdo

### DIFF
--- a/src/execution/executor.c
+++ b/src/execution/executor.c
@@ -66,8 +66,6 @@ void	simple_command_routine(t_ast_node *ast, char *command_line,
 	{
 		if (here_doc > 0)
 			set_here_doc_fd();
-		if (setup_redirections(ast->value.cmd->redir) != 0)
-			exit (1);
 	}
 	execve(command_line, ast->value.cmd->cmd, envp);
 	perror("Failed");

--- a/src/execution/executor_utils.c
+++ b/src/execution/executor_utils.c
@@ -81,19 +81,23 @@ void	exec_command_in_child(t_ast_node *ast, t_shelly *shelly)
 	char	*command_line;
 	char	**env_arr;
 
-	if (ast->value.cmd->cmd[0])
+	if (ast->value.cmd->redir)
 	{
-		builtin_ret = execute_builtin(ast->value.cmd->cmd[0],
-				ast->value.cmd->cmd, shelly);
-		if (builtin_ret != -1)
-			exit(builtin_ret);
-		heredoc = 0;
-		command_line = find_command(shelly, ast->value.cmd->cmd[0]);
-		if (heredoc == -1||!command_line)
-			exit(handle_error(command_line, heredoc));
-		env_arr = get_env_array(shelly);
-		simple_command_routine(ast, command_line, env_arr, heredoc);
-		ft_free_array(env_arr);
-		free(command_line);
+		if (setup_redirections(ast->value.cmd->redir) != 0)
+			exit(1);
 	}
+	if (!ast->value.cmd->cmd[0])
+		exit(0);
+	builtin_ret = execute_builtin(ast->value.cmd->cmd[0],
+			ast->value.cmd->cmd, shelly);
+	if (builtin_ret != -1)
+		exit(builtin_ret);
+	heredoc = 0;
+	command_line = find_command(shelly, ast->value.cmd->cmd[0]);
+	if (heredoc == -1||!command_line)
+		exit(handle_error(command_line, heredoc));
+	env_arr = get_env_array(shelly);
+	simple_command_routine(ast, command_line, env_arr, heredoc);
+	ft_free_array(env_arr);
+	free(command_line);
 }

--- a/src/execution/pipes.c
+++ b/src/execution/pipes.c
@@ -19,20 +19,23 @@ void	exec_pipe_command(t_ast_node *ast, t_shelly *shelly)
 	int		builtin_ret;
 	char	**env_arr;
 
-	if (ast->value.cmd->cmd[0])
+	if (ast->value.cmd->redir)
 	{
-		builtin_ret = execute_builtin(ast->value.cmd->cmd[0],
-				ast->value.cmd->cmd, shelly);
-		if (builtin_ret != -1)
-			exit(builtin_ret);
+		if (setup_redirections(ast->value.cmd->redir) != 0)
+			exit(1);
 	}
+	if (!ast->value.cmd->cmd[0])
+		exit(0);
+	builtin_ret = execute_builtin(ast->value.cmd->cmd[0],
+			ast->value.cmd->cmd, shelly);
+	if (builtin_ret != -1)
+		exit(builtin_ret);
 	here_doc = 0;
 	cmd_line = find_command(shelly, ast->value.cmd->cmd[0]);
 	if (here_doc == -1|| !cmd_line)
 		exit(handle_error(cmd_line, here_doc));
 	env_arr = get_env_array(shelly);
 	simple_command_routine(ast, cmd_line, env_arr, here_doc);
-	// If execve in simple_command_routine fails, we reach here.
 	ft_free_array(env_arr);
 	free(cmd_line);
 	return ;

--- a/tests/test-pipe.c
+++ b/tests/test-pipe.c
@@ -1,5 +1,6 @@
 #include "./tests.h"
 #include <sys/wait.h>
+#include <fcntl.h>
 
 extern char **environ;
 
@@ -29,6 +30,19 @@ static t_ast_node	*make_pipe_node(t_ast_node *left, t_ast_node *right)
 	node->node_type = TOKEN_PIPE;
 	node->value.pipe = p;
 	return (node);
+}
+
+static void	add_test_redir(t_ast_node *node, t_token_type type, char *filename)
+{
+	t_redir	*redir;
+
+	redir = malloc(sizeof(t_redir));
+	redir->type = type;
+	redir->filename = ft_strdup(filename);
+	redir->next = NULL;
+	if (!node->value.cmd)
+		return ;
+	node->value.cmd->redir = redir;
 }
 
 /*
@@ -183,6 +197,61 @@ int	should_pipe_echo_n_no_newline(void)
 	return (EXIT_SUCCESS);
 }
 
+int	should_create_empty_file_on_pipe_with_empty_redir(void)
+{
+	t_shelly	shell = {0};
+	char		*args_l[] = {"echo", "hello", NULL};
+	t_ast_node	*left = make_cmd_node(args_l);
+	t_ast_node	*right = make_cmd_node(NULL);
+	char		*filename = "test_pipe_empty.txt";
+	int			fd;
+
+	init_env_list(&shell, environ);
+	add_test_redir(right, TOKEN_REDIR_OUT, filename);
+	executor(make_pipe_node(left, right), &shell);
+	fd = open(filename, O_RDONLY);
+	if (fd == -1)
+		return (EXIT_FAILURE);
+	if (lseek(fd, 0, SEEK_END) != 0)
+	{
+		close(fd);
+		unlink(filename);
+		return (EXIT_FAILURE);
+	}
+	close(fd);
+	unlink(filename);
+	return (EXIT_SUCCESS);
+}
+
+int	should_write_to_file_on_pipe_with_cmd_and_redir(void)
+{
+	t_shelly	shell = {0};
+	char		*args_l[] = {"echo", "hello", NULL};
+	char		*args_r[] = {"cat", NULL};
+	t_ast_node	*left = make_cmd_node(args_l);
+	t_ast_node	*right = make_cmd_node(args_r);
+	char		*filename = "test_pipe_content.txt";
+	char		buf[16];
+	int			fd;
+	ssize_t		n;
+
+	init_env_list(&shell, environ);
+	add_test_redir(right, TOKEN_REDIR_OUT, filename);
+	executor(make_pipe_node(left, right), &shell);
+	fd = open(filename, O_RDONLY);
+	if (fd == -1)
+		return (EXIT_FAILURE);
+	n = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	unlink(filename);
+	if (n <= 0)
+		return (EXIT_FAILURE);
+	buf[n] = '\0';
+	if (ft_strncmp(buf, "hello\n", 6) != 0)
+		return (EXIT_FAILURE);
+	return (EXIT_SUCCESS);
+}
+
 int	main(void)
 {
 	RUN_TEST(should_pipe_echo_to_cat);
@@ -190,5 +259,7 @@ int	main(void)
 	RUN_TEST(should_pipe_echo_to_grep_match);
 	RUN_TEST(should_pipe_grep_no_match_produces_no_output);
 	RUN_TEST(should_pipe_echo_n_no_newline);
+	RUN_TEST(should_create_empty_file_on_pipe_with_empty_redir);
+	RUN_TEST(should_write_to_file_on_pipe_with_cmd_and_redir);
 	return (0);
 }


### PR DESCRIPTION
Redirout e append sem conteúdo deveriam criar o arquivo indicado vazio. Esse conjunto de commits estabelece esse comportamento e cria alguns casos de teste para assegurar o funcionamento contínuo dessas funcionalidades. Foram também realizados testes manuais e com valgrind, resultando em liberação de memória em todos os casos.